### PR TITLE
filter vip usage, ipv6 vips cause invalid rules because a empty item …

### DIFF
--- a/src/etc/inc/filter.inc
+++ b/src/etc/inc/filter.inc
@@ -1160,6 +1160,7 @@ function filter_generate_optcfg_array() {
 					if (!is_array($oic['vips'])) {
 						$oic['vips'] = array();
 					}
+					$oic['vips'][$vipidx]['mode'] = $vip['mode'];
 					$oic['vips'][$vipidx]['ip'] = $vip['subnet'];
 					if (empty($vip['subnet_bits'])) {
 						$oic['vips'][$vipidx]['sn'] = 32;
@@ -1170,6 +1171,7 @@ function filter_generate_optcfg_array() {
 					if (!is_array($oic['vips6'])) {
 						$oic['vips6'] = array();
 					}
+					$oic['vips6'][$vipidx]['mode'] = $vip['mode'];
 					$oic['vips6'][$vipidx]['ip'] = $vip['subnet'];
 					if (empty($vip['subnet_bits'])) {
 						$oic['vips6'][$vipidx]['sn'] = 128;

--- a/src/etc/inc/vpn.inc
+++ b/src/etc/inc/vpn.inc
@@ -714,6 +714,7 @@ EOD;
 				if (!empty($ph1ent['pre-shared-key'])) {
 					$pskconf .= "{$myid} {$peerid} : PSK 0s" . base64_encode(trim($ph1ent['pre-shared-key'])) . "\n";
 					if (isset($ph1ent['mobile'])) {
+						$pskconf .= "{$myid} %any : PSK 0s" . base64_encode(trim($ph1ent['pre-shared-key'])) . "\n";
 						$pskconf .= " : PSK 0s" . base64_encode(trim($ph1ent['pre-shared-key'])) . "\n";
 					}
 				}


### PR DESCRIPTION
…gets added to the vips list for a interface

(cherry picked from commit c6ebe69d2c0838bc76957b22f98547311c68e700)

- [ ] Redmine Issue: https://redmine.pfsense.org/issues/NNNN
- [ ] Ready for review